### PR TITLE
chore: replacement of websockets lib with aiohttp

### DIFF
--- a/direct-integration-example/requirements.txt
+++ b/direct-integration-example/requirements.txt
@@ -1,4 +1,4 @@
-websockets==12.0
+aiohttp
 wave
 argparse
 asyncio

--- a/direct-integration-example/streaming-microphone.py
+++ b/direct-integration-example/streaming-microphone.py
@@ -8,6 +8,8 @@ import uuid
 
 import numpy as np
 
+EOF_MESSAGE = '{"eof": 1}'
+
 try:
     import sounddevice as sd
 except ImportError:
@@ -107,9 +109,6 @@ async def receive_transcription(ws):
             if response_data["eos"]:
                 print("Complete transcript: ", ", ".join(complete_sentences))
                 break
-        elif msg.type == WSMsgType.BINARY:
-            # Handle binary messages if necessary
-            pass
         elif msg.type == WSMsgType.CLOSE:
             print("WebSocket connection closed by server.")
             break
@@ -172,7 +171,7 @@ async def run(server_addr: str, device: int, stop_event: asyncio.Event):
             if not recv_task.done():
                 await recv_task
 
-            await ws.send_str('{"eof": 1}')
+            await ws.send_str(EOF_MESSAGE)
 
 
 async def send_audio(ws, input_generator, stop_event):

--- a/direct-integration-example/streaming.py
+++ b/direct-integration-example/streaming.py
@@ -1,5 +1,4 @@
-import websockets
-import argparse
+import aiohttp
 import asyncio
 import wave
 import sys
@@ -7,6 +6,7 @@ import json
 import os
 import uuid
 import ssl
+import argparse
 
 ssl_context = ssl.create_default_context()
 ssl_context.check_hostname = False
@@ -21,90 +21,76 @@ def int_or_str(text):
         return text
 
 
-# Asynchronous function to receive transcription from the server
 async def receive_transcription(ws):
     complete_sentences = []
-    while True:
-        response = await ws.recv()
-        try:
-            response_data = json.loads(response)
+    async for msg in ws:
+        if msg.type == aiohttp.WSMsgType.TEXT:
+            try:
+                response_data = json.loads(msg.data)
 
-            # Complete response from the ASR server contains json data
-            # print(response_data)
-            # sample response: {'call_id': 'ffae3d29833c', 'segment_id': '966339932cc3', 'eos': False, 'type': 'partial', 'text': 'मुझे'}
+                call_id = response_data.get("call_id")
+                segment_id = response_data.get("segment_id")
+                transcript_type = response_data.get("type")
+                transcript_text = response_data.get("text")
+                end_of_stream = response_data.get("eos", False)
 
-            # Unique identifier associated with every streaming connection
-            call_id = response_data["call_id"]
+                if transcript_type == "complete" and transcript_text != "":
+                    complete_sentences.append(transcript_text)
 
-            # Unique identifier associated with every speech segment during the entire active socket connection
-            # Usually a speech segment is 4-10 seconds long
-            segment_id = response_data["segment_id"]
+                print(
+                    f"Received data: Call_id={call_id}, "
+                    f"Segment_id={segment_id}, "
+                    f"EOS={end_of_stream}, "
+                    f"Type={transcript_type}, "
+                    f"Text={transcript_text}"
+                )
 
-            # Partial transcript corresponding to every streaming audio chunk
-            # Complete transcript generated for each speech segment when speech segment end is reached
-            transcript_type = response_data["type"]
+                if end_of_stream:
+                    print("Complete transcript: ", ", ".join(complete_sentences))
+                    break
 
-            # Transcript text
-            transcript_text = response_data["text"]
+            except json.JSONDecodeError:
+                print(f"Received a non-JSON response: {msg.data}")
 
-            # If 'eos' is True, marks the end of the streaming connection
-            end_of_stream = response_data["eos"]
-
-            if transcript_type == "complete" and transcript_text != "":
-                complete_sentences.append(response_data["text"])
-
-            print(
-                f"Received data: Call_id={call_id}, "
-                f"Segment_id={segment_id}, "
-                f"EOS={end_of_stream}, "
-                f"Type={transcript_type}, "
-                f"Text={transcript_text}"
-            )
-
-            if response_data["eos"]:
-                print("Complete transcript: ", ", ".join(complete_sentences))
-                break
-        except json.JSONDecodeError:
-            print(f"Received a non-JSON response: {response}")
+        elif msg.type == aiohttp.WSMsgType.ERROR:
+            print(f"WebSocket error: {ws.exception()}")
+            break
+        elif msg.type == aiohttp.WSMsgType.CLOSED:
+            break
 
 
-# function to send audio data to the server
 async def send_audio(ws, wf, buffer_size, interval_seconds):
     while True:
         data = wf.readframes(buffer_size)
-        if len(data) == 0:
+        if not data:
             break
-        await ws.send(data)
+        await ws.send_bytes(data)
         await asyncio.sleep(interval_seconds)
-    await ws.send('{"eof": 1}')
+    # Send EOF JSON message
+    await ws.send_str('{"eof": 1}')
 
 
-# function to run the test
-async def run_test(api_key, customer_id):
+async def run_test(api_key, customer_id, uri, filepath):
     request_headers = {
         "x-api-key": api_key,
         "x-customer-id": customer_id,
     }
     chunk_duration_ms = 100
 
-    try:
-        connect_kwargs = {
-            "extra_headers": request_headers,
-        }
-        if args.uri.startswith("wss://"):
-            connect_kwargs["ssl"] = ssl_context
+    connector = aiohttp.TCPConnector(ssl=ssl_context if uri.startswith("wss://") else None)
 
-        async with websockets.connect(args.uri, **connect_kwargs) as ws:
-            wf = wave.open(args.file, "rb")
-            (channels, sample_width, sample_rate, num_samples, _, _) = wf.getparams()
-            print(
-                f"Channels = {channels}, Sample Rate = {sample_rate} Hz, Sample width = {sample_width} bytes",
-                file=sys.stderr,
-            )
+    async with aiohttp.ClientSession(connector=connector, headers=request_headers) as session:
+        try:
+            async with session.ws_connect(uri) as ws:
+                wf = wave.open(filepath, "rb")
+                channels, sample_width, sample_rate, num_samples, _, _ = wf.getparams()
+                print(
+                    f"Channels = {channels}, Sample Rate = {sample_rate} Hz, Sample width = {sample_width} bytes",
+                    file=sys.stderr,
+                )
 
-            # Sending initial configuration to the server
-            await ws.send(
-                json.dumps(
+                # Send initial config
+                config_msg = json.dumps(
                     {
                         "config": {
                             "sample_rate": sample_rate,
@@ -122,45 +108,34 @@ async def run_test(api_key, customer_id):
                         }
                     }
                 )
-            )
+                await ws.send_str(config_msg)
 
-            buffer_size = int(sample_rate * chunk_duration_ms / 1000)
-            interval_seconds = chunk_duration_ms / 1000.0
+                buffer_size = int(sample_rate * chunk_duration_ms / 1000)
+                interval_seconds = chunk_duration_ms / 1000.0
 
-            send_task = asyncio.create_task(
-                send_audio(ws, wf, buffer_size, interval_seconds)
-            )
-            recv_task = asyncio.create_task(receive_transcription(ws))
+                send_task = asyncio.create_task(send_audio(ws, wf, buffer_size, interval_seconds))
+                recv_task = asyncio.create_task(receive_transcription(ws))
 
-            await asyncio.gather(send_task, recv_task)
-    except websockets.exceptions.ConnectionClosed as e:
-        # Catching WebSocket connection closure
-        print(
-            f"WebSocket connection closed with code: {e.code}, reason: {e.reason}",
-            file=sys.stderr,
-        )
-    except websockets.exceptions.InvalidStatusCode as e:
-        # Catching invalid status code errors
-        print(
-            f"WebSocket connection failed with status code: {e.status_code}",
-            file=sys.stderr,
-        )
-        if e.status_code == 401:
-            print("Invalid API key or customer ID.", file=sys.stderr)
-        elif e.status_code == 402:
-            print("Insufficient balance.", file=sys.stderr)
-        elif e.status_code == 403:
-            print("Customer has been deactivated", file=sys.stderr)
-    except Exception as e:
-        # General exception handler for other errors
-        print(f"An error occurred: {str(e)}", file=sys.stderr)
-        import traceback
+                await asyncio.gather(send_task, recv_task)
 
-        print("Full error traceback:", file=sys.stderr)
-        print(traceback.format_exc(), file=sys.stderr)
+        except aiohttp.WSServerHandshakeError as e:
+            print(f"WebSocket handshake failed with status code: {e.status}", file=sys.stderr)
+            if e.status == 401:
+                print("Invalid API key or customer ID.", file=sys.stderr)
+            elif e.status == 402:
+                print("Insufficient balance.", file=sys.stderr)
+            elif e.status == 403:
+                print("Customer has been deactivated", file=sys.stderr)
+        except aiohttp.ClientConnectionError as e:
+            print(f"Connection error: {str(e)}", file=sys.stderr)
+        except Exception as e:
+            print(f"An error occurred: {str(e)}", file=sys.stderr)
+            import traceback
+
+            print("Full error traceback:", file=sys.stderr)
+            print(traceback.format_exc(), file=sys.stderr)
 
 
-# Main asynchronous function
 async def main():
     global args
 
@@ -173,9 +148,7 @@ async def main():
         return
 
     parser = argparse.ArgumentParser(add_help=False)
-
     args, remaining = parser.parse_known_args()
-
     parser = argparse.ArgumentParser(
         description="ASR Server",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -194,9 +167,8 @@ async def main():
     args = parser.parse_args(remaining)
 
     if args.file:
-        await run_test(api_key, customer_id)
-
-    if not args.file:
+        await run_test(api_key, customer_id, args.uri, args.file)
+    else:
         print(
             "This script is meant to show how to connect to Navana Streaming Speech Recognition API endpoint through websockets\n"
         )

--- a/direct-integration-example/streaming.py
+++ b/direct-integration-example/streaming.py
@@ -8,6 +8,8 @@ import uuid
 import ssl
 import argparse
 
+EOF_MESSAGE = '{"eof": 1}'
+
 ssl_context = ssl.create_default_context()
 ssl_context.check_hostname = False
 ssl_context.verify_mode = ssl.CERT_NONE
@@ -67,7 +69,7 @@ async def send_audio(ws, wf, buffer_size, interval_seconds):
         await ws.send_bytes(data)
         await asyncio.sleep(interval_seconds)
     # Send EOF JSON message
-    await ws.send_str('{"eof": 1}')
+    await ws.send_str(EOF_MESSAGE)
 
 
 async def run_test(api_key, customer_id, uri, filepath):


### PR DESCRIPTION
This PR replaces the websockets library with aiohttp for WebSocket handling.

The change was made because the websockets library introduced a non-backward-compatible change to the headers parameter, which causes issues with older versions. Additionally, the latest websockets versions require a newer Python version and are not compatible with Python 3.8. To maintain compatibility and avoid breaking changes, aiohttp has been used as a more stable alternative.